### PR TITLE
IRO-2679 Fixed errors on Iron Fish node start.

### DIFF
--- a/electron/ironfish/IronFishManager.ts
+++ b/electron/ironfish/IronFishManager.ts
@@ -98,7 +98,11 @@ export class IronFishManager implements IIronfishManager {
     try {
       //Initializing Iron Fish SDK
       this.initStatus = IronFishInitStatus.INITIALIZING_SDK
-      this.sdk = await IronfishSdk.init()
+      this.sdk = await IronfishSdk.init({
+        configOverrides: {
+          nodeWorkers: 0,
+        },
+      })
 
       //Initializing Iron Fish node
       this.initStatus = IronFishInitStatus.INITIALIZING_NODE


### PR DESCRIPTION
- Disabled workers in worker pool

Problem is in wrong path to `worker.js`
[`getWorkerPath`](https://github.com/iron-fish/ironfish/blob/6769ec16520298e2fdd6313d71f6df8889989d6e/ironfish/src/workerPool/worker.ts#L289) return wrong path to this file