### PR TITLE
Fix application crash when clear input while send $IRON

### DIFF
--- a/src/routes/Send/Send.tsx
+++ b/src/routes/Send/Send.tsx
@@ -283,7 +283,7 @@ const Send: FC = () => {
       <SendFlow
         isOpen={startSendFlow}
         onClose={() => setStart(false)}
-        amount={decodeIron(amount)}
+        amount={decodeIron(amount || 0)}
         from={account}
         to={contact}
         memo={notes}


### PR DESCRIPTION
The application crash when clear input on "Send $IRON"

Steps to reproduce:
1. Go to "Send$IRON"
2. Clear input

Actual result:
Application crash
```
uncaught Error: invalid decimal value (argument="value", value="", code=INVALID_ARGUMENT
```
![image](https://user-images.githubusercontent.com/29353655/215188770-2c477112-803c-4e03-a3eb-4f6469196e57.png)

After fix:
As we see the input is empty and application still functional
![image](https://user-images.githubusercontent.com/29353655/215188958-0cdf8839-c760-4e72-87fc-d77c9a2cd230.png)

