### PR TITLE
Fix wrong styles for dark and light mode

### DIFF
--- a/src/routes/Send/Send.tsx
+++ b/src/routes/Send/Send.tsx
@@ -129,14 +129,14 @@ const Send: FC = () => {
   })
   const $colors = useColorModeValue(
     {
-      bg: NAMED_COLORS.DEEP_BLUE,
-      color: NAMED_COLORS.WHITE,
-      warningBg: '#FFEDE8',
-    },
-    {
       bg: NAMED_COLORS.WHITE,
       color: NAMED_COLORS.DEEP_BLUE,
       warningBg: '#3E251B',
+    },
+    {
+      bg: NAMED_COLORS.DEEP_BLUE,
+      color: NAMED_COLORS.WHITE,
+      warningBg: '#FFEDE8',
     }
   )
 
@@ -169,7 +169,7 @@ const Send: FC = () => {
             alignItems="center"
             w="inherit"
             h="16rem"
-            bg={`${$colors.bg} !important`}
+            bg={$colors.bg}
             color={$colors.color}
             mb="2rem"
             borderRadius="0.25rem"


### PR DESCRIPTION
There was a mistake in the order of parameters for useColorModeValue first should be "light" second "dark". As a result we have the following issue
Light mode:
![image](https://user-images.githubusercontent.com/29353655/215205920-15d17ed6-a5da-406b-af6e-3fa0ea00403b.png)
Dark mode:
![image](https://user-images.githubusercontent.com/29353655/215205990-1808e5a3-4bba-4b36-b6ac-7c6f3d004181.png)

After fix:
Light mode:
![image](https://user-images.githubusercontent.com/29353655/215206449-6e53ff9f-8688-4779-8fa3-ae874f36fd28.png)
Dark mode:
![image](https://user-images.githubusercontent.com/29353655/215206512-f668df97-835e-45dc-9cc7-12e3969d213d.png)
 