### PR TITLE
Do not use commas while copy mnemonic

### DIFF
--- a/src/routes/Onboarding/CreateAccount/CreateStep.tsx
+++ b/src/routes/Onboarding/CreateAccount/CreateStep.tsx
@@ -56,7 +56,7 @@ const CreateStep: FC<StepProps> = ({
           <Flex gap="0.4375rem" mb="-0.4375rem">
             <h6>Mnemonic phrase</h6>
             <CopyToClipboardButton
-              value={phrase?.join(', ')}
+              value={phrase?.join(' ')}
               copyTooltipText="Copy to clipboard"
               copiedTooltipText="Copied"
             />

--- a/src/routes/Onboarding/ImportAccount.tsx
+++ b/src/routes/Onboarding/ImportAccount.tsx
@@ -177,7 +177,7 @@ const MnemonicPhraseTab: FC<DesktopModeProps> = ({ desktopMode, onImport }) => {
           <Flex gap="0.4375rem" mb="-0.4375rem">
             <h6>Mnemonic phrase</h6>
             <CopyToClipboardButton
-              value={phrase?.join(', ')}
+              value={phrase?.join(' ')}
               copyTooltipText="Copy to clipboard"
               copiedTooltipText="Copied"
             />


### PR DESCRIPTION
The mnemonic phrase should not be separated by commas they should be separated by spaces only.

**Reason 1:**
People want to save the phrases in the same format as they will be used during import

**Reason 2:**
it is an accepted standard used on other wallets Keplr, Metamask, Sui Wallet etc...

**Reason 3:**
The Ironfish CLI returns mnemonics separated by spaces only and customers expect just copy phrases and do not want to edit something.

Example during export:
```
root@test:~# ironfish wallet:export --mnemonic
Detected Language as 'English', exporting:
aware matrix planet quick eyebrow tray limb melt daring tray home robust describe spike hire father remind rabbit horror sight caution oil carry north
```
As we can see here also used just space


