### PR TITLE
adds 'in development' warning to top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# 🚧 The Iron Fish Wallet App is in development 🚧
+
+The Iron Fish Wallet App is still under active development, but has not been released yet.
+
 # Iron Fish Wallet application
 
 This repo is Electron-based application for managing Accounts in Iron Fish network using [Iron Fish modules](https://github.com/iron-fish/ironfish).


### PR DESCRIPTION
lots of people are finding the wallet app on github and trying to install and use it as we launch mainnet.